### PR TITLE
fix: auth thread start fail in python2.6

### DIFF
--- a/zmq/auth/thread.py
+++ b/zmq/auth/thread.py
@@ -164,8 +164,12 @@ class ThreadAuthenticator(object):
         self.pipe.bind(self.pipe_endpoint)
         self.thread = AuthenticationThread(self.context, self.pipe_endpoint, encoding=self.encoding, log=self.log)
         self.thread.start()
-        if not self.thread.started.wait(timeout=10):
-            raise RuntimeError("Authenticator thread failed to start")
+        # Changed in version 2.7: Previously, the method always returned None.
+        if sys.version_info < (2,7):
+            self.thread.started.wait(timeout=10)
+        else:
+            if not self.thread.started.wait(timeout=10):
+                raise RuntimeError("Authenticator thread failed to start")
 
     def stop(self):
         """Stop the authentication thread"""


### PR DESCRIPTION
Event.wait()  fun always return NONE in python 2.6, so auth thread terminate in python verison 2.6
